### PR TITLE
FIX1 revised Python package setup-file and Dockerfile for openssl library

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,11 @@ include LICENSE.python
 include MANIFEST.in
 include package.json
 include *.rst
+include prepare.sh
+recursive-include third_party/openssl *
+recursive-include bbc1/common/libbbcsig *
+recursive-include bbc1/common *
+recursive-include bbc1/core/ethereum *
 graft django
 prune django/contrib/admin/bin
 graft docs

--- a/bbc1/common/bbclib.py
+++ b/bbc1/common/bbclib.py
@@ -28,7 +28,7 @@ from bbc1.common.bbc_error import *
 
 directory, filename = os.path.split(os.path.realpath(__file__))
 from ctypes import *
-libbbcsig = cdll.LoadLibrary("%s/libbbcsig.so" % directory)
+libbbcsig = CDLL("%s/libbbcsig.so" % directory)
 
 
 domain_global_0 = binascii.a2b_hex("0000000000000000000000000000000000000000000000000000000000000000")
@@ -436,7 +436,6 @@ class BBcTransaction:
             signature = (c_byte * 64)()
             libbbcsig.sign(keypair.private_key_len, keypair.private_key, 32, self.digest(), signature)
             s = bytes(signature)
-            print(s)
         else:
             set_error(code=EOTHER, txt="sig_type %d is not supported" % keypair.type)
             return None

--- a/bbc1/common/libbbcsig/Makefile
+++ b/bbc1/common/libbbcsig/Makefile
@@ -3,14 +3,25 @@ OPENSSL_DIR=../../../third_party/openssl
 INCS = -I$(OPENSSL_DIR)/include -I$(OPENSSL_DIR)
 LIBS = $(OPENSSL_DIR)/libssl.a $(OPENSSL_DIR)/libcrypto.a
 
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+LFLAGS0 = 
+LFLAGS1 = 
+LFLAGS2 = 
+else
+LFLAGS0 = -fPIC
+LFLAGS1 = -Wl,--whole-archive
+LFLAGS2 = -Wl,--no-whole-archive
+endif
+
 .c.o:
-	$(CC) $(INCS) -c $<
+	$(CC) $(INCS) $(LFLAGS0) -c $<
 
 all:
 	make libbbcsig.so
 
 libbbcsig.so:	libbbcsig.o
-	gcc -shared -o $@ $(LIBS) $<
+	gcc -shared -o $@ $(LFLAGS1) $(LIBS) $(LFLAGS2) $<
 	install -m 0644 $@ ../
 
 openssl:

--- a/docker/Dockerfile_git
+++ b/docker/Dockerfile_git
@@ -19,17 +19,21 @@ WORKDIR /root/
 # for apline
 #RUN apk --update --no-cache add openrc bash openssh sudo g++ git tzdata musl-dev linux-headers python3 python3-dev zlib-dev libjpeg-turbo-dev libffi-dev openssl-dev && python3 -m ensurepip
 # for ubuntu
-RUN apt-get update && apt-get install -y tzdata openssh-server python3 python3-dev python3-venv libffi-dev net-tools
+RUN apt-get update && apt-get install -y git tzdata openssh-server python3 python3-dev python3-venv libffi-dev net-tools autoconf automake libtool libssl-dev make
 
 RUN mkdir -p ${SHARE_DIR} && echo "root:${PASSWORD}" | chpasswd
 
 # for ubuntu
 RUN sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
 
-RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && pip install --upgrade pip setuptools && pip install -r /tmp/requirements.txt && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
+RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && pip install --upgrade pip setuptools && pip install wheel && pip install -r /tmp/requirements.txt && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
 
 RUN mkdir -p ${SHARE_DIR}
 
-ADD bbc1.tar.gz /root/bbc1/
+ADD bbc1.tar.gz /root/
+
+WORKDIR /root/bbc1/
+
+RUN sh prepare.sh
 
 CMD bash /entrypoint.sh

--- a/docker/Dockerfile_pip
+++ b/docker/Dockerfile_pip
@@ -19,14 +19,14 @@ WORKDIR /root/
 # for alpine
 #RUN apk --update --no-cache add openrc bash openssh sudo g++ git tzdata musl-dev linux-headers python3 python3-dev zlib-dev libjpeg-turbo-dev libffi-dev openssl-dev && python3 -m ensurepip
 #for ubuntu
-RUN apt-get update && apt-get install -y tzdata openssh-server python3 python3-dev python3-venv libffi-dev net-tools
+RUN apt-get update && apt-get install -y tzdata openssh-server python3 python3-dev python3-venv libffi-dev net-tools autoconf automake libtool libssl-dev make
 
 RUN mkdir -p ${SHARE_DIR} && echo "root:${PASSWORD}" | chpasswd
 
 # for ubuntu
 RUN sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
 
-RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && pip install --upgrade pip setuptools && pip install -r /tmp/requirements.txt && pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple bbc1 && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
+RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && pip install --upgrade pip setuptools && pip install -r /tmp/requirements.txt && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
 
 RUN mkdir -p ${SHARE_DIR}
 

--- a/docker/docker-bbc1.sh
+++ b/docker/docker-bbc1.sh
@@ -32,7 +32,7 @@ case $1 in
 
     gitbuild)
     	cp ../requirements.txt .
-	    cd .. && git archive HEAD -o bbc1.tar.gz && cd docker
+	    cd .. && git archive-all bbc1.tar.gz && cd docker
 	    mv ../bbc1.tar.gz .
 	    docker build -t ${CONTAINER_NAME} -f Dockerfile_git .
 	    rm requirements.txt bbc1.tar.gz

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,8 @@ source /root/.pythonenv/bin/activate
 if [ -e /root/bbc1 ]; then
   cd /root/bbc1/bbc1/core
   exec python bbc_core.py -w /root/.bbc1
+#  /usr/sbin/sshd -D -e 
 else
   exec bbc_core.py -w /root/.bbc1
+#  /usr/sbin/sshd -D -e 
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
+git-archive-all==1.16.4
 pyOpenSSL>=16.2.0
+jinja2==2.8.1
+ecdsa==0.13
+Flask>=0.10.1
 requests>=2.12.4
 pytest>=3.0.5
 gevent>=1.2.1
 msgpack-python>=0.4.8
+populus
+bbc1
+

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,38 @@
 import tempfile, sys, os, shutil
+import subprocess
 from os import path
-from setuptools import setup
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+here = path.abspath(path.dirname(__file__))
 
 with open('README.rst') as f:
     readme = f.read()
 
+class MyInstall(install):
+    def run(self):
+        try:
+            subprocess.call(['/bin/sh', 'prepare.sh'], cwd=here)
+        except Exception as e:
+            print(e)
+            print("Error compiling openssl.")
+            exit(1)
+        else:
+            install.run(self)
+
 bbc1_requires = [
                  'pyOpenSSL>=16.2.0',
+                 'jinja2==2.8.1',
                  'ecdsa==0.13',
                  'Flask>=0.10.1',
                  'requests>=2.12.4',
                  'pytest>=3.0.5',
                  'gevent>=1.2.1',
+                 'populus',
                  'msgpack-python>=0.4.8']
 
-bbc1_packages = ['bbc1', 'bbc1.core', 'bbc1.common', 'bbc1.app']
+bbc1_packages = ['bbc1', 'bbc1.core', 'bbc1.core.ethereum', 'bbc1.common', 'bbc1.common.libbbcsig', 'bbc1.app']
 
 bbc1_commands = [
                  'bbc1/core/bbc_core.py',
@@ -29,19 +47,20 @@ bbc1_classifiers = [
                     'Programming Language :: Python :: 3.6',
                     'Topic :: Software Development']
 
-
 setup(
     name='bbc1',
-    version='0.7',
-    packages=bbc1_packages,
+    version='0.7.2',
     description='A core system of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain/bbc1',
     author='beyond-blockchain.org',
     author_email='bbc1-dev@beyond-blockchain.org',
     license='Apache License 2.0',
+    classifiers=bbc1_classifiers,
+    cmdclass={'install': MyInstall},
+    packages=bbc1_packages,
     scripts=bbc1_commands,
     install_requires=bbc1_requires,
-    classifier=bbc1_classifiers,
+    data_files = [("/bbc1/common", ["bbc1/common/libbbcsig.so"])],
     zip_safe=False)
 

--- a/tests/test_bbclib.py
+++ b/tests/test_bbclib.py
@@ -28,7 +28,7 @@ asset_content = b'abcdefg'
 
 print("\n")
 print("private_key:", binascii.b2a_hex(keypair1.private_key))
-print("private_key(pem):\n", keypair1.get_private_key_in_pem().decode())
+print("private_key(pem):\n", keypair1.get_private_key_in_pem())
 print("public_key:", binascii.b2a_hex(keypair1.public_key))
 
 


### PR DESCRIPTION
enabled to work for on-sight-compiling openssl library on pip install.
update version to 0.7.2 in setup.py.