### PR TITLE
Fix/docker python version

### DIFF
--- a/docker/Dockerfile_git
+++ b/docker/Dockerfile_git
@@ -19,14 +19,18 @@ WORKDIR /root/
 # for apline
 #RUN apk --update --no-cache add openrc bash openssh sudo g++ git tzdata musl-dev linux-headers python3 python3-dev zlib-dev libjpeg-turbo-dev libffi-dev openssl-dev && python3 -m ensurepip
 # for ubuntu
-RUN apt-get update && apt-get install -y git tzdata openssh-server python3 python3-dev python3-venv libffi-dev net-tools autoconf automake libtool libssl-dev make
+RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:jonathonf/python-3.6
+
+RUN apt-get update && apt-get install -y git tzdata openssh-server python3.6 python3.6-dev python3-pip python3.6-venv libffi-dev net-tools autoconf automake libtool libssl-dev make pkg-config
 
 RUN mkdir -p ${SHARE_DIR} && echo "root:${PASSWORD}" | chpasswd
+
+RUN rm /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python
 
 # for ubuntu
 RUN sed -i 's/prohibit-password/yes/' /etc/ssh/sshd_config
 
-RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && pip install --upgrade pip setuptools && pip install wheel && pip install -r /tmp/requirements.txt && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
+RUN /bin/bash -c "python3 -m venv ${VENV_DIR} && source ${VENV_DIR}/bin/activate && python3 -m pip install --upgrade pip setuptools && python3 -m pip install wheel && python3 -m pip install pystan && python3 -m pip install -r /tmp/requirements.txt && rm -r ~/.cache && deactivate && echo \"source ${VENV_DIR}/bin/activate\" >> /root/.bashrc"
 
 RUN mkdir -p ${SHARE_DIR}
 

--- a/examples/file_proof/README.md
+++ b/examples/file_proof/README.md
@@ -18,7 +18,7 @@ This app allows a user to do the following:
     python file_proof.py keypair
     python file_proof.py setup
     ```
-    .private_key and .public_key are crated.
+    .private_key and .public_key are created.
 3. Execute commands in another terminal
     The commands must be executed in the directory having the key pair.
     * Store a file


### PR DESCRIPTION
latest ubuntu version is 10.4.
python version is 3.5 on ubuntu 10.4

bbc1 require python 3.6 or later

run-time error occurred with escrow example.
![image](https://user-images.githubusercontent.com/14107599/34080812-4782b3c4-e387-11e7-8e16-994ea8b99906.png)

I think there are some problems.
so, i upgrade to python 3.6.