### PR TITLE
Feature/libbbcsig windows dll

### DIFF
--- a/bbc1/common/bbclib.py
+++ b/bbc1/common/bbclib.py
@@ -166,8 +166,8 @@ class KeyPair:
         if privkey is not None:
             memmove(self.private_key, bytes(privkey), sizeof(self.private_key))
         if pubkey is not None:
-            self.public_key_len = len(pubkey)
-            memmove(self.public_key, bytes(pubkey), self.public_key_len)
+            self.public_key_len = c_int32(len(pubkey))
+            memmove(self.public_key, bytes(pubkey), self.public_key_len.value)
 
         if privkey is None and pubkey is None:
             self.generate()

--- a/bbc1/common/bbclib.py
+++ b/bbc1/common/bbclib.py
@@ -28,7 +28,11 @@ from bbc1.common.bbc_error import *
 
 directory, filename = os.path.split(os.path.realpath(__file__))
 from ctypes import *
-libbbcsig = CDLL("%s/libbbcsig.so" % directory)
+
+if os.name == "nt":
+    libbbcsig = CDLL("%s/libbbcsig.dll" % directory)
+else:
+    libbbcsig = CDLL("%s/libbbcsig.so" % directory)
 
 
 domain_global_0 = binascii.a2b_hex("0000000000000000000000000000000000000000000000000000000000000000")
@@ -215,12 +219,12 @@ class KeyPair:
         return intval
 
     def get_private_key_in_der(self):
-        der_data = (c_byte * 256)()
+        der_data = (c_byte * 512)()     # 256 -> 512
         der_len = libbbcsig.output_der(self.private_key_len, self.private_key, byref(der_data))
         return bytes(bytearray(der_data)[:der_len])
 
     def get_private_key_in_pem(self):
-        pem_data = (c_char * 256)()
+        pem_data = (c_char * 512)()     # 256 -> 512
         pem_len = libbbcsig.output_pem(self.private_key_len, self.private_key, byref(pem_data))
         return pem_data.value
 

--- a/bbc1/common/libbbcsig/dllmain.c
+++ b/bbc1/common/libbbcsig/dllmain.c
@@ -1,0 +1,29 @@
+#ifdef _WIN32
+#include <windows.h>
+
+/**
+ * 
+ */
+BOOL WINAPI DllMain(
+	HINSTANCE hinstDLL,
+	DWORD dwReason,
+	LPVOID lpReserved
+) {
+
+	switch (dwReason) {
+	case DLL_PROCESS_ATTACH:
+		break;
+	case DLL_THREAD_ATTACH:
+		break;
+	case DLL_THREAD_DETACH:
+		break;
+	case DLL_PROCESS_DETACH:
+		break;
+	default:
+		break;
+	}
+
+	return TRUE;
+}
+
+#endif

--- a/bbc1/common/libbbcsig/libbbcsig.c
+++ b/bbc1/common/libbbcsig/libbbcsig.c
@@ -398,7 +398,7 @@ int VS_STDCALL output_pem(int privkey_len, uint8_t *privkey, uint8_t *pem_out)
     PEM_write_bio_ECPrivateKey(out, eckey, NULL, NULL, 0, NULL, NULL);
     BIO_get_mem_ptr(out, &buf);
 
-    int len = strlen(buf->data);
+	int len = buf->length;
     memcpy(pem_out, buf->data, len);
 
     BIO_free_all(out);

--- a/bbc1/common/libbbcsig/libbbcsig.c
+++ b/bbc1/common/libbbcsig/libbbcsig.c
@@ -16,7 +16,13 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+
+#include "libbbcsig.h"
+#include <string.h>
+
+#ifndef _WIN32
 #include <strings.h>
+#endif
 
 #include <openssl/ec.h>      // for EC_GROUP_new_by_curve_name, EC_GROUP_free, EC_KEY_new, EC_KEY_set_group, EC_KEY_generate_key, EC_KEY_free
 #include <openssl/ecdsa.h>   // for ECDSA_do_sign, ECDSA_do_verify
@@ -29,7 +35,8 @@
 #include <crypto/ec/ec_lcl.h>
 
 
-bool sign(int privkey_len, uint8_t *privkey, int hash_len, uint8_t *hash, uint8_t *sig)
+VS_DLL_EXPORT
+bool VS_STDCALL sign(int privkey_len, uint8_t *privkey, int hash_len, uint8_t *hash, uint8_t *sig)
 {
     BN_CTX *ctx = BN_CTX_new();
     EC_KEY *eckey = EC_KEY_new();
@@ -63,7 +70,8 @@ bool sign(int privkey_len, uint8_t *privkey, int hash_len, uint8_t *hash, uint8_
     return true;
 }
 
-int verify(int point_len, const uint8_t *point,
+VS_DLL_EXPORT
+int VS_STDCALL verify(int point_len, const uint8_t *point,
            int hash_len,uint8_t *hash,
            int sig_len, const uint8_t *sig)
 {
@@ -103,8 +111,8 @@ int verify(int point_len, const uint8_t *point,
     return verify_status;
 }
 
-
-bool generate_keypair(uint8_t pubkey_type, int *pubkey_len, uint8_t *pubkey,
+VS_DLL_EXPORT
+bool VS_STDCALL generate_keypair(uint8_t pubkey_type, int *pubkey_len, uint8_t *pubkey,
                       int *privkey_len, uint8_t *privkey)
 {
     BN_CTX *ctx = BN_CTX_new();
@@ -146,8 +154,8 @@ bool generate_keypair(uint8_t pubkey_type, int *pubkey_len, uint8_t *pubkey,
     return true;
 }
 
-
-bool get_public_key_uncompressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey)
+VS_DLL_EXPORT
+bool VS_STDCALL get_public_key_uncompressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey)
 {
     BN_CTX *ctx = BN_CTX_new();
     EC_KEY *eckey = EC_KEY_new();
@@ -181,8 +189,8 @@ bool get_public_key_uncompressed(int privkey_len, uint8_t *privkey, int *pubkey_
     return true;
 }
 
-
-bool get_public_key_compressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey)
+VS_DLL_EXPORT
+bool VS_STDCALL get_public_key_compressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey)
 {
     BN_CTX *ctx = BN_CTX_new();
     EC_KEY *eckey = EC_KEY_new();
@@ -216,8 +224,8 @@ bool get_public_key_compressed(int privkey_len, uint8_t *privkey, int *pubkey_le
     return true;
 }
 
-
-bool convert_from_der(long der_len, const unsigned char *der,
+VS_DLL_EXPORT
+bool VS_STDCALL convert_from_der(long der_len, const unsigned char *der,
                       uint8_t pubkey_type,
                       int *pubkey_len, uint8_t *pubkey,
                       int *privkey_len, uint8_t *privkey)
@@ -267,8 +275,8 @@ bool convert_from_der(long der_len, const unsigned char *der,
     return true;
 }
 
-
-bool convert_from_pem(const char *pem,
+VS_DLL_EXPORT
+bool VS_STDCALL convert_from_pem(const char *pem,
                       uint8_t pubkey_type,
                       int *pubkey_len, uint8_t *pubkey,
                       int *privkey_len, uint8_t *privkey)
@@ -322,7 +330,8 @@ bool convert_from_pem(const char *pem,
     return true;
 }
 
-int output_der(int privkey_len, uint8_t *privkey, uint8_t *der_out)
+VS_DLL_EXPORT
+int VS_STDCALL output_der(int privkey_len, uint8_t *privkey, uint8_t *der_out)
 {
     BN_CTX *ctx = BN_CTX_new();
     EC_KEY *eckey = EC_KEY_new();
@@ -357,8 +366,8 @@ int output_der(int privkey_len, uint8_t *privkey, uint8_t *der_out)
     return der_len;
 }
 
-
-int output_pem(int privkey_len, uint8_t *privkey, uint8_t *pem_out)
+VS_DLL_EXPORT
+int VS_STDCALL output_pem(int privkey_len, uint8_t *privkey, uint8_t *pem_out)
 {
     BN_CTX *ctx = BN_CTX_new();
     EC_KEY *eckey = EC_KEY_new();

--- a/bbc1/common/libbbcsig/libbbcsig.def
+++ b/bbc1/common/libbbcsig/libbbcsig.def
@@ -1,0 +1,11 @@
+LIBRARY libbbcsig
+
+EXPORTS sign
+	verify
+	generate_keypair
+	get_public_key_uncompressed
+	get_public_key_compressed
+	convert_from_der
+	convert_from_pem
+	output_der
+	output_pem

--- a/bbc1/common/libbbcsig/libbbcsig.h
+++ b/bbc1/common/libbbcsig/libbbcsig.h
@@ -1,0 +1,144 @@
+#ifndef LIBBBCSIG_H
+#define LIBBBCSIG_H
+
+#include <stdbool.h>
+
+#ifdef _WIN32
+#define VS_DLL_EXPORT __declspec(dllexport)
+#define VS_STDCALL __stdcall
+#else
+#define VS_DLL_EXPORT 
+#define VS_STDCALL 
+#endif
+
+//#ifdef _WIN32
+/**
+ *
+ */
+typedef unsigned char uint8_t;
+//#else
+//#endif
+
+/**
+ * 
+ *
+ * @param [in] privkey_len
+ * @param [in] privkey
+ * @param [in] hash_len
+ * @param [in] hash
+ * @param [out] sig
+ * @return bool 
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL sign(int privkey_len, uint8_t *privkey, int hash_len, uint8_t *hash, uint8_t *sig);
+
+/**
+ *
+ *
+ * @param [in] point_len
+ * @param [in] point
+ * @param [in] hash_len
+ * @param [in] hash
+ * @param [in] sig_len
+ * @param [in] sig
+ * @return int 
+ */
+VS_DLL_EXPORT
+int VS_STDCALL verify(int point_len, const uint8_t *point,
+	int hash_len, uint8_t *hash,
+	int sig_len, const uint8_t *sig);
+
+/**
+ *
+ *
+ * @param [in] pubkey_type
+ * @param [out] pubkey_len
+ * @param [out] pubkey
+ * @param [out] privkey_len
+ * @param [out] privkey
+ * @return bool 
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL generate_keypair(uint8_t pubkey_type, int *pubkey_len, uint8_t *pubkey,
+	int *privkey_len, uint8_t *privkey);
+
+/**
+ *
+ * 
+ * @param [in] privkey_len
+ * @param [in] privkey
+ * @param [out] pubkey_len
+ * @param [out] pubkey
+ * @return bool 
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL get_public_key_uncompressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey);
+
+/**
+ *
+ *
+ * @param [in] privkey_len
+ * @param [in] privkey
+ * @param [out] pubkey_len
+ * @param [out] pubkey
+ * @return bool
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL get_public_key_compressed(int privkey_len, uint8_t *privkey, int *pubkey_len, uint8_t *pubkey);
+
+/**
+ *
+ * 
+ * @param [in] der_len
+ * @param [in] der
+ * @param [in] pubkey_type
+ * @param [out] pubkey_len
+ * @param [out] pubkey
+ * @param [out] privkey_len
+ * @return bool 
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL convert_from_der(long der_len, const unsigned char *der,
+	uint8_t pubkey_type,
+	int *pubkey_len, uint8_t *pubkey,
+	int *privkey_len, uint8_t *privkey);
+
+/**
+ *
+ *
+ * @param [in] pem
+ * @param [in] pubkey_type
+ * @param [out] pubkey_len
+ * @param [out] pubkey
+ * @param [out] privkey_len
+ *@return bool
+ */
+VS_DLL_EXPORT
+bool VS_STDCALL convert_from_pem(const char *pem,
+	uint8_t pubkey_type,
+	int *pubkey_len, uint8_t *pubkey,
+	int *privkey_len, uint8_t *privkey);
+
+/**
+ *
+ *
+ * @param [in] privkey_len
+ * @param [in] privkey
+ * @param [out] der_out
+ * @return int 
+ */
+VS_DLL_EXPORT
+int VS_STDCALL output_der(int privkey_len, uint8_t *privkey, uint8_t *der_out);
+
+/**
+ *
+ *
+ * @param [in] privkey_len
+ * @param [in] privkey
+ * @param [out] pem_out
+ * @return int
+ */
+VS_DLL_EXPORT
+int VS_STDCALL output_pem(int privkey_len, uint8_t *privkey, uint8_t *pem_out);
+
+#endif

--- a/bbc1/common/libbbcsig/pybbcsig.py
+++ b/bbc1/common/libbbcsig/pybbcsig.py
@@ -1,0 +1,124 @@
+import os
+import binascii
+from ctypes import *
+
+
+class PyBBcSigSecp256k1(object):
+
+    def __init__(self):
+        """
+        """
+        if os.name == "nt":
+            self.lib = windll.LoadLibrary("libbbcsig.dll")
+        else:
+            self.lib = cdll.LoadLibrary("libbbcsig.so")
+
+    def generate_keypair(self, pubkey_type):
+        """
+        """
+        privkey_len = c_int32(32)
+        privkey     = (c_byte * privkey_len.value)()
+        pubkey_len  = c_int32(65)
+        pubkey      = (c_byte * pubkey_len.value)()
+
+        ret = self.lib.generate_keypair(pubkey_type, byref(pubkey_len), pubkey, byref(privkey_len), privkey)
+        if ret:
+            return ( bytes(bytearray(pubkey)[:pubkey_len.value]), bytes(bytearray(privkey)[:privkey_len.value]) )
+        else:
+            return (None, None)
+
+    def sign(self, privkey, digest):
+        """
+        """
+        signature = (c_byte * 64)()
+
+        ret = self.lib.sign(len(privkey), privkey, 32, digest, signature)
+        if ret:
+            return bytes(signature)
+        else:
+            return None
+
+    def output_der(self, privkey):
+        """
+        """
+        der_data = (c_byte * 512)()
+
+        der_len = self.lib.output_der(len(privkey), privkey, byref(der_data))
+        # print("der_len = {}".format(der_len))
+        if der_len > 0:
+            return bytes(bytearray(der_data)[:der_len])
+        else:
+            return None
+
+    def convert_from_der(self, der_data, pubkey_type):
+        """
+        """
+        privkey_len = c_int32(32)
+        privkey     = (c_byte * privkey_len.value)()
+        pubkey_len  = c_int32(65)
+        pubkey      = (c_byte * pubkey_len.value)()
+
+        ret = self.lib.convert_from_der(len(der_data), der_data, pubkey_type, byref(pubkey_len), pubkey, byref(privkey_len), privkey)
+        if ret:
+            return ( bytes(bytearray(pubkey)[:pubkey_len.value]), bytes(bytearray(privkey)[:privkey_len.value]) )
+        else:
+            return (None, None)
+
+    def get_public_key_compressed(self, privkey):
+        """
+        """
+        pubkey_len  = c_int32(65)
+        pubkey      = (c_byte * pubkey_len.value)()
+
+        ret = self.lib.get_public_key_compressed(len(privkey), privkey, byref(pubkey_len), pubkey)
+        if ret:
+            return bytes(bytearray(pubkey)[:pubkey_len.value])
+        else:
+            return None
+
+    def get_public_key_uncompressed(self, privkey):
+        """
+        """
+        pubkey_len  = c_int32(65)
+        pubkey      = (c_byte * pubkey_len.value)()
+
+        ret = self.lib.get_public_key_uncompressed(len(privkey), privkey, byref(pubkey_len), pubkey)
+        if ret:
+            return bytes(bytearray(pubkey)[:pubkey_len.value])
+        else:
+            return None
+
+    def verify(self, pubkey, digest, signature):
+        """
+        """
+        ret = self.lib.verify(len(pubkey), pubkey, 32, digest, 64, signature)
+        return ret
+
+    def output_pem(self, privkey):
+        """
+        """
+        pem_data = (c_byte * 512)()
+
+        pem_len = self.lib.output_pem(len(privkey), privkey, byref(pem_data))
+        # print("pem_len = {}".format(pem_len))
+        if pem_len > 0:
+            array = bytearray(pem_data)[:(pem_len + 1)]
+            array[pem_len] = 0
+            return bytes(array)
+        else:
+            return None
+
+    def convert_from_pem(self, pem_data, pubkey_type):
+        """
+        """
+        privkey_len = c_int32(32)
+        privkey     = (c_byte * privkey_len.value)()
+        pubkey_len  = c_int32(65)
+        pubkey      = (c_byte * pubkey_len.value)()
+
+        ret = self.lib.convert_from_pem(pem_data, pubkey_type, byref(pubkey_len), pubkey, byref(privkey_len), privkey)
+        if ret:
+            return ( bytes(bytearray(pubkey)[:pubkey_len.value]), bytes(bytearray(privkey)[:privkey_len.value]) )
+        else:
+            return None
+

--- a/bbc1/common/libbbcsig/test_ecdsa.py
+++ b/bbc1/common/libbbcsig/test_ecdsa.py
@@ -1,8 +1,11 @@
 import binascii
+import os
 from ctypes import *
 
-lib = cdll.LoadLibrary("libbbcsig.so")
-
+if os.name == "nt":
+    lib = windll.LoadLibrary("libbbcsig.dll")
+else:
+    lib = cdll.LoadLibrary("libbbcsig.so")
 
 test_digest = binascii.a2b_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 privkey_len = c_int32(32)
@@ -22,7 +25,7 @@ print(lib.sign(privkey_len, privkey, privkey_len, test_digest, signature))
 print(binascii.b2a_hex(signature))
 
 print("# -- output_der()")
-der_data = (c_byte * 256)()
+der_data = (c_byte * 512)()     # 256 -> 512
 der_len = lib.output_der(privkey_len, privkey, byref(der_data))
 print("DER: len=",der_len, "  dat=", binascii.b2a_hex(bytearray(der_data)[:der_len]))
 
@@ -58,6 +61,6 @@ res = lib.verify(pubkey_len, pubkey, 32, test_digest, 64, signature)
 print("result:", res)
 
 print("# -- output_pem()")
-pem = (c_char * 256)()
+pem = (c_char * 512)()      # 256 -> 512
 length = lib.output_pem(privkey_len, privkey, byref(pem))
 print("PEM: len=", length, " dat=", pem.value)

--- a/bbc1/common/libbbcsig/test_pybbcsig.py
+++ b/bbc1/common/libbbcsig/test_pybbcsig.py
@@ -1,0 +1,203 @@
+import os
+#import unittest
+import pybbcsig
+import binascii
+
+
+def _is_windows():
+    """
+    """
+    return os.name == "nt"
+
+
+sig = pybbcsig.PyBBcSigSecp256k1()
+
+in_privkey = b'\xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb'
+in_pubkey = b'\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+in_pubkey_compressed = b'\x03\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad'
+
+in_test_digest = binascii.a2b_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+in_signature_nt = b'Dz\xe5\x84$\xf5_\x19\x9d\xda\x83\x00(O\x91\xec\x18MP\xbd\xef\xa2\x9b\x96\xb3\x9d\xea\xb5\xf9\x93;\xa4\xafB\xe9:\x9e\xa5G\xc79\xe1\xb7\xfaS)\xfd\x82\x0e\xa7\x13|\xe6\xc8\xebX\x91[\x8a$\xe3\xf0\xf4\r'
+
+in_signature_posix = b'B)\n@\xe666\xb310z5\x8c\x99\x06u\xe7\xa9}\\\xdc\xa5\x93\x8a\xc6\xb2by\xe1`L\xe8\x95\x18\xd3?\x1f\x1d\x81\x96\xd6\x01\x96\xe2\x80y\x0fz3\xde\xd8\x18\xbd\xbc\xce\xc2\xf6\xdf\xde\x8c\xdd\xb8\xb0\xd5'
+if _is_windows():
+    in_signature = in_signature_nt
+else:
+    in_signature = in_signature_posix
+
+in_der_nt = b'0\x82\x01\x13\x02\x01\x01\x04 \xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb\xa0\x81\xa50\x81\xa2\x02\x01\x010,\x06\x07*\x86H\xce=\x01\x01\x02!\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xfc/0\x06\x04\x01\x00\x04\x01\x07\x04A\x04y\xbef~\xf9\xdc\xbb\xacU\xa0b\x95\xce\x87\x0b\x07\x02\x9b\xfc\xdb-\xce(\xd9Y\xf2\x81[\x16\xf8\x17\x98H:\xdaw&\xa3\xc4e]\xa4\xfb\xfc\x0e\x11\x08\xa8\xfd\x17\xb4H\xa6\x85T\x19\x9cG\xd0\x8f\xfb\x10\xd4\xb8\x02!\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xba\xae\xdc\xe6\xafH\xa0;\xbf\xd2^\x8c\xd06AA\x02\x01\x01\xa1D\x03B\x00\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+
+in_der_posix = b'0t\x02\x01\x01\x04 \xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb\xa0\x07\x06\x05+\x81\x04\x00\n\xa1D\x03B\x00\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+if _is_windows():
+    in_der = in_der_nt
+else:
+    in_der = in_der_posix
+
+in_pem_nt = b'-----BEGIN EC PRIVATE KEY-----\nMIIBEwIBAQQg1lm8I0n+7QDheKq0VtCcAeKa/dJhq2bLFKxNjsoyPbuggaUwgaIC\nAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wv\nMAYEAQAEAQcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncm\no8RlXaT7/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu\n3OavSKA7v9JejNA2QUECAQGhRANCAAQPZCjdj1L3QIbnBAbDS+x12f7pZGWVjBYO\nc0roElFgrSkuvfscgJZwErVv/XI72KZg7IVprRTOa3M4FyZ/7tDB\n-----END EC PRIVATE KEY-----\n\x00'
+
+in_pem_posix = b'-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEINZZvCNJ/u0A4XiqtFbQnAHimv3SYatmyxSsTY7KMj27oAcGBSuBBAAK\noUQDQgAED2Qo3Y9S90CG5wQGw0vsddn+6WRllYwWDnNK6BJRYK0pLr37HICWcBK1\nb/1yO9imYOyFaa0UzmtzOBcmf+7QwQ==\n-----END EC PRIVATE KEY-----\n\x00'
+if _is_windows():
+    in_pem = in_pem_nt
+else:
+    in_pem = in_pem_posix
+
+
+def test_keypair():
+    """
+    """
+    pubkey, privkey = sig.generate_keypair(0)
+    # print("pubkey = {}".format(pubkey))
+    # print("privkey = {}".format(privkey))
+    assert (len(privkey) == 32)
+    assert (len(pubkey) == 65)
+
+
+def test_sign():
+    """
+    """
+    assert (len(in_privkey) == 32)
+
+    signature = sig.sign(in_privkey, in_test_digest)     # 毎回変わる
+    # print("signature = {}".format(signature))
+    assert (len(signature) == 64)
+
+
+def test_der():
+    """
+    """
+    assert (len(in_privkey) == 32)
+
+    der = sig.output_der(in_privkey)
+    # print("der = {}".format(der))
+    # print("len(der) = {}".format(len(der)))
+    if _is_windows():
+        assert (len(der) == 279)
+    else:
+        assert (len(der) == 118)
+    assert (der == in_der)
+
+
+def test_from_der():
+    """
+    """
+    pubkey, privkey = sig.convert_from_der(in_der, 0)
+    # print("pubkey = {}".format(pubkey))
+    # print("privkey = {}".format(privkey))
+    assert (len(privkey) == 32)
+    assert (len(pubkey) == 65)
+    assert (privkey == in_privkey)
+    assert (pubkey == in_pubkey)
+
+
+def test_from_der2():
+    """
+    """
+    if _is_windows():
+        der = in_der_posix
+    else:
+        der = in_der_nt
+
+    pubkey, privkey = sig.convert_from_der(der, 0)
+    # print("pubkey = {}".format(pubkey))
+    # print("privkey = {}".format(privkey))
+    assert (len(privkey) == 32)
+    assert (len(pubkey) == 65)
+    assert (privkey == in_privkey)
+    assert (pubkey == in_pubkey)
+
+
+def test_pubkey_compressed():
+    """
+    """
+    assert (len(in_privkey) == 32)
+
+    pubkey = sig.get_public_key_compressed(in_privkey)
+    # print("pubkey = {}".format(pubkey))
+    # print("len(pubkey) = {}".format(len(pubkey)))
+    assert (len(pubkey) == 33)
+    assert (pubkey == in_pubkey_compressed)
+
+def test_pubkey_uncompressed():
+    """
+    """
+    assert (len(in_privkey) == 32)
+
+    pubkey = sig.get_public_key_uncompressed(in_privkey)
+    # print("pubkey = {}".format(pubkey))
+    # print("len(pubkey) = {}".format(len(pubkey)))
+    assert (len(pubkey) == 65)
+    assert (pubkey == in_pubkey)
+
+
+def test_verify():
+    """
+    """
+    # print("len(in_signature) = {}".format(len(in_signature)))
+    assert (len(in_signature) == 64)
+
+    ret = sig.verify(in_pubkey, in_test_digest, in_signature)
+    # print("ret = {}".format(ret))
+    assert (ret > 0)
+    assert (ret == 1)
+
+
+def test_verify2():
+    """
+    """
+    if _is_windows():
+        signature = in_signature_posix
+    else:
+        signature = in_signature_nt
+
+    # print("len(signature) = {}".format(len(signature)))
+    assert (len(signature) == 64)
+
+    ret = sig.verify(in_pubkey, in_test_digest, signature)
+    # print("ret = {}".format(ret))
+    assert (ret > 0)
+    assert (ret == 1)
+
+
+def test_pem():
+    """
+    """
+    assert (len(in_privkey) == 32)
+
+    pem = sig.output_pem(in_privkey)
+    # print("pem = {}".format(pem))
+    # print("len(pem) = {}".format(len(pem)))
+    if _is_windows():
+        assert (len(pem) == (438 + 1))
+    else:
+        assert(len(pem) == (223 + 1))
+    assert (pem == in_pem)
+
+
+def test_from_pem():
+    """
+    """
+    pubkey, privkey = sig.convert_from_pem(in_pem, 0)
+    # print("pubkey = {}".format(pubkey))
+    # print("privkey = {}".format(privkey))
+    assert (len(privkey) == 32)
+    assert (len(pubkey) == 65)
+    assert (privkey == in_privkey)
+    assert(pubkey == in_pubkey)
+
+
+def test_from_pem2():
+    """
+    """
+    if _is_windows():
+        pem = in_pem_posix
+    else:
+        pem = in_pem_nt
+
+    pubkey, privkey = sig.convert_from_pem(pem, 0)
+    # print("pubkey = {}".format(pubkey))
+    # print("privkey = {}".format(privkey))
+    assert (len(privkey) == 32)
+    assert (len(pubkey) == 65)
+    assert (privkey == in_privkey)
+    assert (pubkey == in_pubkey)

--- a/docs/libbbcsig_dll_build_for_Windows_x64_ja.md
+++ b/docs/libbbcsig_dll_build_for_Windows_x64_ja.md
@@ -1,0 +1,66 @@
+﻿libbbcsig の 64bit Windows DLL ビルドについて
+=========
+ここでは、libbbcsig を 64bit Windows DLL にビルドする方法について記載する。
+libbbcsig は内部で OpenSSL の関数を使用しているため、まず、OpenSSL を Windows 向けにビルドする必要がある。
+
+## OpenSSL のビルド
+
+### ビルド環境の構築
+
+以下のソフトウェアが必要になる。インストールを行う。
+
+* [Visual Studio Community 2017](https://www.microsoft.com/ja-jp/dev/products/community.aspx)
+* [ActiveParl](https://www.activestate.com/activeperl)
+
+### OpenSSL ソースダウンロード & ビルド
+
+[https://www.openssl.org/](https://www.openssl.org/) からソースをダウンロードする。
+
+※ 以下、 1.0.2n の場合について記載する。
+
+ソースの展開ディレクトリに移動し、以下のコマンドを実行する。
+
+`cd <<ソースの展開ディレクトリ>>\openssl-1.0.2n`
+
+`perl Configure no-asm --prefix=..\x64 VC-WIN64A`
+
+`ms\do_win64a.bat`
+
+`nmake -f ms\nt.mak clean`
+
+`nmake -f ms\nt.mak install`
+
+※ **nt.mak** を指定し、スタティックライブラリにすること。
+※ `..\x64\lib` ディレクトリに、libeay32.lib と ssleay32.lib ができれば OK
+
+## libbbcsig のビルド
+
+### libbbcsig の Visual Studio プロジェクト生成
+
+Visual Studio で空のプロジェクトを新規作成する。(名称: libbbcsig)
+
+`bbc1/common/libbbcsig` にある以下のファイルをプロジェクトに追加する。
+
+* libbbcsig.h
+* libbbcsig.c
+* dllmain.c
+* libbbcsig.def
+
+### libbbcsig プロジェクトの設定
+
+プロジェクトのプロパティを以下のように設定する。
+
+|項目|設定値|
+|:-:|:-:|
+|プラットフォーム| x64|
+|構成の種類|dll|
+|追加のインクルードディレクトリ|<<ソースの展開ディレクトリ>>\x64\include|
+|追加のインクルードディレクトリ|<<ソースの展開ディレクトリ>>\openssl-1.0.2n|
+|ランタイムライブラリ|/MT|
+|追加の依存ファイル|<<ソースの展開ディレクトリ>>\x64\lib\libeay32.lib|
+|追加の依存ファイル|<<ソースの展開ディレクトリ>>\x64\lib\ssleay32.lib|
+|モジュール定義ファイル|libbbcsig.def|
+
+### ビルド
+
+ビルドを行い、`x64\Debug` または `x64\Release` ディレクトリに libbbcsig.dll が出来ることを確認する。

--- a/tests/test_bbclib_KeyPair.py
+++ b/tests/test_bbclib_KeyPair.py
@@ -1,0 +1,97 @@
+import sys
+sys.path.append('.')
+sys.path.append('..')
+
+import os
+import bbc1.common.bbclib as bbclib
+import binascii
+#import unittest
+
+def _is_windows():
+    """
+    """
+    return os.name == "nt"
+
+
+in_privkey = b'\xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb'
+in_pubkey = b'\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+
+in_der_nt = b'0\x82\x01\x13\x02\x01\x01\x04 \xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb\xa0\x81\xa50\x81\xa2\x02\x01\x010,\x06\x07*\x86H\xce=\x01\x01\x02!\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xfc/0\x06\x04\x01\x00\x04\x01\x07\x04A\x04y\xbef~\xf9\xdc\xbb\xacU\xa0b\x95\xce\x87\x0b\x07\x02\x9b\xfc\xdb-\xce(\xd9Y\xf2\x81[\x16\xf8\x17\x98H:\xdaw&\xa3\xc4e]\xa4\xfb\xfc\x0e\x11\x08\xa8\xfd\x17\xb4H\xa6\x85T\x19\x9cG\xd0\x8f\xfb\x10\xd4\xb8\x02!\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xba\xae\xdc\xe6\xafH\xa0;\xbf\xd2^\x8c\xd06AA\x02\x01\x01\xa1D\x03B\x00\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+
+in_der_posix = b'0t\x02\x01\x01\x04 \xd6Y\xbc#I\xfe\xed\x00\xe1x\xaa\xb4V\xd0\x9c\x01\xe2\x9a\xfd\xd2a\xabf\xcb\x14\xacM\x8e\xca2=\xbb\xa0\x07\x06\x05+\x81\x04\x00\n\xa1D\x03B\x00\x04\x0fd(\xdd\x8fR\xf7@\x86\xe7\x04\x06\xc3K\xecu\xd9\xfe\xe9de\x95\x8c\x16\x0esJ\xe8\x12Q`\xad).\xbd\xfb\x1c\x80\x96p\x12\xb5o\xfdr;\xd8\xa6`\xec\x85i\xad\x14\xceks8\x17&\x7f\xee\xd0\xc1'
+if _is_windows():
+    in_der = in_der_nt
+else:
+    in_der = in_der_posix
+
+in_pem_nt = b'-----BEGIN EC PRIVATE KEY-----\nMIIBEwIBAQQg1lm8I0n+7QDheKq0VtCcAeKa/dJhq2bLFKxNjsoyPbuggaUwgaIC\nAQEwLAYHKoZIzj0BAQIhAP////////////////////////////////////7///wv\nMAYEAQAEAQcEQQR5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmEg62ncm\no8RlXaT7/A4RCKj9F7RIpoVUGZxH0I/7ENS4AiEA/////////////////////rqu\n3OavSKA7v9JejNA2QUECAQGhRANCAAQPZCjdj1L3QIbnBAbDS+x12f7pZGWVjBYO\nc0roElFgrSkuvfscgJZwErVv/XI72KZg7IVprRTOa3M4FyZ/7tDB\n-----END EC PRIVATE KEY-----\n\x00'
+
+in_pem_posix = b'-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEINZZvCNJ/u0A4XiqtFbQnAHimv3SYatmyxSsTY7KMj27oAcGBSuBBAAK\noUQDQgAED2Qo3Y9S90CG5wQGw0vsddn+6WRllYwWDnNK6BJRYK0pLr37HICWcBK1\nb/1yO9imYOyFaa0UzmtzOBcmf+7QwQ==\n-----END EC PRIVATE KEY-----\n\x00'
+if _is_windows():
+    in_pem = in_pem_nt
+else:
+    in_pem = in_pem_posix
+
+
+def test_keypair_generate():
+    """
+    """
+    keypair = bbclib.KeyPair()
+    keypair.generate()
+    assert (keypair.private_key_len.value == 32)
+    assert (keypair.public_key_len.value == 65)
+
+
+def test_keypair_pubkey():
+    """
+    """
+    keypair = bbclib.KeyPair(type=bbclib.KeyType.ECDSA_SECP256k1, privkey=in_privkey)
+    keypair.mk_keyobj_from_private_key()
+    assert (keypair.public_key_len.value == 65)
+    assert (bytes(keypair.public_key)[:keypair.public_key_len.value] == in_pubkey)
+
+
+def test_keypair_der():
+    """
+    """
+    keypair = bbclib.KeyPair(type=bbclib.KeyType.ECDSA_SECP256k1, privkey=in_privkey, pubkey=in_pubkey)
+
+    der = keypair.get_private_key_in_der()
+    assert (der == in_der)
+
+    keypair.mk_keyobj_from_private_key_der(der)
+    assert (bytes(keypair.private_key)[:keypair.private_key_len.value] == in_privkey)
+    assert (bytes(keypair.public_key)[:keypair.public_key_len.value] == in_pubkey)
+
+
+def test_keypair_pem():
+    """
+    """
+    keypair = bbclib.KeyPair(type=bbclib.KeyType.ECDSA_SECP256k1, privkey=in_privkey, pubkey=in_pubkey)
+
+    pem = keypair.get_private_key_in_pem()
+    assert (bytes(pem) == in_pem[:(len(in_pem) - 1)])  # ヌル終端を取り除いて比較する。
+
+    keypair.mk_keyobj_from_private_key_pem(str(pem))   # 文字列化する。
+    assert (bytes(keypair.private_key)[:keypair.private_key_len.value] == in_privkey)
+    assert (bytes(keypair.public_key)[:keypair.public_key_len.value] == in_pubkey)
+
+
+def test_keypair_sign_and_verify():
+    """
+    """
+    digest = binascii.a2b_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    keypair = bbclib.KeyPair(type=bbclib.KeyType.ECDSA_SECP256k1, privkey=in_privkey, pubkey=in_pubkey)
+    signature = keypair.sign(digest)
+    print("signature = {}".format(signature))
+
+    ret = keypair.verify(digest, signature)
+    # print("ret = {}".format(ret))
+    assert (ret == 1)
+
+    not_digest = binascii.a2b_hex("bbbbbb")
+
+    ret = keypair.verify(not_digest, signature)
+    # print("ret = {}".format(ret))
+    assert (ret == 0)

--- a/tests/test_message_key_types.py
+++ b/tests/test_message_key_types.py
@@ -1,0 +1,75 @@
+import sys
+sys.path.extend(["../"])
+
+
+#import unittest
+import bbc1.common.message_key_types as message_key_types
+import bbc1.common.bbc_error as bbc_error
+
+from bbc1.common.bbclib import ServiceMessageType as MsgType
+# dummy start.
+#class MsgType:
+#    MESSAGE = 34
+# dummy end.
+
+
+def _bytes_to_str(bytes_str):
+    """
+    """
+    return bytes_str.decode('utf-8')
+
+
+
+def test_to_4byte():
+    """
+    """
+    val = message_key_types.to_4byte(7)
+    assert (val == b'\x00\x00\x00\x07')
+
+    val = message_key_types.to_4byte(1, 0x20)
+    assert (val == b'\x00\x00\x00\x21')
+
+    val = message_key_types.to_4byte(8, 0x30)
+    assert (val == b'\x00\x00\x00\x38')
+
+    val = message_key_types.to_4byte(2, 0x70)
+    assert (val == b'\x00\x00\x00\x72')
+
+
+def test_make_message():
+    """
+    """
+    data = {  }
+    message = message_key_types.make_message(message_key_types.PayloadType.Type_msgpack, data, 0)
+    # print(message)
+    assert (message == b'\x00\x01\x00\x00\x00\x00\x00\x01\x80')
+    assert (message[:message_key_types.Message.HEADER_LEN] == b'\x00\x01\x00\x00\x00\x00\x00\x01')
+
+
+def test_make_message2():
+    """
+    """
+    data = {
+        message_key_types.KeyType.command: MsgType.MESSAGE,
+        message_key_types.KeyType.asset_group_id: "asset_group_id_001",
+        message_key_types.KeyType.source_user_id: "source_user_id_12345",
+        message_key_types.KeyType.query_id: "query_id_67890",
+        message_key_types.KeyType.status: bbc_error.ESUCCESS,
+    }
+    message = message_key_types.make_message(message_key_types.PayloadType.Type_msgpack, data, 0)
+    # print(message)
+    assert (message[:message_key_types.Message.HEADER_LEN] == b'\x00\x01\x00\x00\x00\x00\x00S')
+
+    msg_obj = message_key_types.Message()
+    msg_obj.recv(bytes(message))
+    parsed_data = msg_obj.parse()
+    assert (msg_obj.payload_type == message_key_types.PayloadType.Type_msgpack)
+    assert (msg_obj.format_version == 0)
+    assert (msg_obj.msg_len == 83)        # 'S' == 83
+    print(parsed_data)
+    assert (parsed_data[message_key_types.KeyType.command] == MsgType.MESSAGE)
+    assert (_bytes_to_str(parsed_data[message_key_types.KeyType.asset_group_id]) == "asset_group_id_001")
+    assert (_bytes_to_str(parsed_data[message_key_types.KeyType.source_user_id]) == "source_user_id_12345")
+    assert (_bytes_to_str(parsed_data[message_key_types.KeyType.query_id]) == "query_id_67890")
+    assert (parsed_data[message_key_types.KeyType.status] == bbc_error.ESUCCESS)
+


### PR DESCRIPTION
Be able to build libbbcsig Windows DLL.

libbbcsig を Windows DLL にビルド出来るようにしました。
`bbc1/docs/libbbcsig_dll_build_for_Windows_x64_ja.md` に Windows DLL のビルド方法を記載。
Linux および macOS でのビルドは今まで通りです。(※ Linux については、こちらでビルド確認済)

変更箇所のテストは以下のコマンドで可能です。

In `libbbcsig` directory:
`pytest -v`

In `tests` directory:
`pytest test_bbclib_KeyPair.py -v`