### PR TITLE
refactor: refactor domain setup procedure in bbc_core

### DIFF
--- a/bbc1/core/bbc_config.py
+++ b/bbc1/core/bbc_config.py
@@ -65,7 +65,6 @@ current_config = {
     },
     'domains': {
         '0000000000000000000000000000000000000000000000000000000000000000': {
-            'special_domain': True,
             'module': 'p2p_domain0',
             'static_nodes': {
                 # id : [ipv4, ipv6, port]
@@ -75,6 +74,7 @@ current_config = {
             },
         },
     },
+    'use_ledger_subsystem': False,
     'ethereum': {
         'chain_id': DEFAULT_ETHEREUM_CHAIN_ID,
         'port': DEFAULT_ETHEREUM_GETH_PORT,
@@ -143,24 +143,7 @@ class BBcConfig:
                 'peer_list': {
                     # id : [ipv4, ipv6, port]
                 },
-                'asset_group_ids': {
-                    # id: { config }
-                }
             }
         if domain_id_str in self.config['domains']:
             return self.config['domains'][domain_id_str]
         return None
-
-    def get_asset_group_config(self, domain_id, asset_group_id, create_if_new=False):
-        dc = self.get_domain_config(domain_id, create_if_new=create_if_new)
-        if dc is None:
-            return None
-        asset_group_str = bbclib.convert_id_to_string(asset_group_id)
-        if asset_group_str not in dc['asset_group_ids']:
-            dc['asset_group_ids'][asset_group_str] = {
-                'storage_type': StorageType.FILESYSTEM,
-                'storage_path': None,
-                'advertise_in_domain0': False,
-                'max_body_size': bbclib.DEFAULT_MAX_BODY_SIZE,
-            }
-        return dc['asset_group_ids'][asset_group_str]

--- a/bbc1/core/bbc_ledger.py
+++ b/bbc1/core/bbc_ledger.py
@@ -5,6 +5,7 @@ import sqlite3
 import sys
 sys.path.extend(["../../"])
 from bbc1.common import logger
+from bbc1.core.bbc_types import ResourceType
 
 import binascii
 
@@ -16,15 +17,6 @@ auxiliary_db_definition = [
     ["id", "INTEGER"], ["resource_id", "BLOB"], ["asset_group_id", "BLOB"],
     ["resource_type", "INTEGER"], ["data", "BLOB"],
 ]
-
-
-class ResourceType:
-    Transaction_data = 0
-    Asset_ID = 1
-    Asset_file = 2
-    Edge_incoming = 3
-    Edge_outgoing = 4
-    Owner_asset = 5
 
 
 class BBcLedger:

--- a/bbc1/core/bbc_storage.py
+++ b/bbc1/core/bbc_storage.py
@@ -21,7 +21,6 @@ import sys
 sys.path.extend(["../../"])
 from bbc1.common import logger
 from bbc1.common.bbclib import StorageType
-from bbc1.common import bbclib
 
 
 class BBcStorage:

--- a/bbc1/core/bbc_types.py
+++ b/bbc1/core/bbc_types.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2017 beyond-blockchain.org.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import sys
+sys.path.extend(["../../", os.path.abspath(os.path.dirname(__file__))])
+from bbc1.common.message_key_types import to_2byte
+
+
+class ResourceType:
+    Transaction_data = 0
+    Asset_ID = 1
+    Asset_file = 2
+    Edge_incoming = 3
+    Edge_outgoing = 4
+    Owner_asset = 5
+
+
+class InfraMessageTypeBase:
+    DOMAIN_PING = to_2byte(0)
+    NOTIFY_LEAVE = to_2byte(1)
+    NOTIFY_PEERLIST = to_2byte(2)
+    START_TO_REFRESH = to_2byte(3)
+    REQUEST_PING = to_2byte(4)
+    RESPONSE_PING = to_2byte(5)
+
+    NOTIFY_CROSS_REF = to_2byte(0, 0x10)        # only used in domain_global_0
+    ADVERTISE_DOMAIN_INFO = to_2byte(1, 0x10)   # only used in domain_global_0
+
+    REQUEST_STORE = to_2byte(0, 0x40)
+    RESPONSE_STORE = to_2byte(1, 0x40)
+    RESPONSE_STORE_COPY = to_2byte(2, 0x40)
+    REQUEST_FIND_USER = to_2byte(3, 0x40)
+    RESPONSE_FIND_USER = to_2byte(4, 0x40)
+    REQUEST_FIND_VALUE = to_2byte(5, 0x40)
+    RESPONSE_FIND_VALUE = to_2byte(6, 0x40)
+    MESSAGE_TO_USER = to_2byte(7, 0x40)

--- a/bbc1/core/command.py
+++ b/bbc1/core/command.py
@@ -25,7 +25,8 @@ DEFAULT_SERV_ADDR = '127.0.0.1'
 
 def parser():
     usage = 'python {} [--coreport <number>] [--p2pport <number>] [--workingdir <dir>] ' \
-            '[--config <filename>] [--globaldomain] [--ip4addr <IP addr>] [--ip6addr <IPv6 addr>] ' \
+            '[--config <filename>] [--globaldomain] [--useledgersubsystem] ' \
+            '[--ip4addr <IP addr>] [--ip6addr <IPv6 addr>] ' \
             '[--log <filename>] [--verbose_level <string>] [--daemon] [--kill] [--help]'.format(__file__)
     argparser = ArgumentParser(usage=usage)
     argparser.add_argument('-cp', '--coreport', type=int, default=DEFAULT_CORE_PORT,
@@ -39,6 +40,9 @@ def parser():
     argparser.add_argument('--globaldomain',
                            action='store_true',
                            help='connect with domain_global_0')
+    argparser.add_argument('--useledgersubsystem',
+                           action='store_true',
+                           help='use ledger_subsystem')
     argparser.add_argument('--ip4addr', type=str, default=None,
                            help='IPv4 address exposed to the external network')
     argparser.add_argument('--ip6addr', type=str, default=None,

--- a/bbc1/core/p2p_domain0.py
+++ b/bbc1/core/p2p_domain0.py
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import binascii
-import time
 import random
 import struct
 
@@ -23,7 +22,7 @@ import sys
 sys.path.extend(["../../"])
 from bbc1.common import bbclib
 from bbc1.common.message_key_types import to_2byte, PayloadType, KeyType
-from bbc1.core.bbc_network import InfraMessageTypeBase
+from bbc1.core.bbc_types import InfraMessageTypeBase
 from bbc1.core import query_management, simple_cluster
 
 

--- a/bbc1/core/simple_cluster.py
+++ b/bbc1/core/simple_cluster.py
@@ -17,13 +17,13 @@ limitations under the License.
 import binascii
 import time
 import random
-import socket
 
 import sys
 sys.path.extend(["../../"])
-from bbc1.common.message_key_types import KeyType, PayloadType, to_2byte
-from bbc1.core.bbc_ledger import ResourceType
-from bbc1.core.bbc_network import InfraMessageTypeBase, DomainBase
+from bbc1.common.message_key_types import KeyType, PayloadType
+from bbc1.core.bbc_types import ResourceType
+from bbc1.core.bbc_network import DomainBase
+from bbc1.core.bbc_types import InfraMessageTypeBase
 from bbc1.core import query_management
 
 

--- a/tests/test_bbc_core.py
+++ b/tests/test_bbc_core.py
@@ -7,7 +7,7 @@ import time
 
 import sys
 sys.path.extend(["../"])
-from bbc1.core.bbc_ledger import ResourceType
+from bbc1.core.bbc_types import ResourceType
 from bbc1.common import bbclib
 from bbc1.common.message_key_types import KeyType
 from testutils import prepare, start_core_thread, get_core_client, make_client
@@ -70,6 +70,7 @@ class TestBBcCore(object):
         cores, clients = get_core_client()
         for i in range(core_num):
             cores[i].networking.create_domain(network_module="simple_cluster", domain_id=domain_id)
+            cores[i].ledger_manager.add_domain(domain_id)
             cores[i].send_message = dummy_send_message
             cores[i].storage_manager.set_storage_path(domain_id)
 
@@ -91,6 +92,7 @@ class TestBBcCore(object):
             transaction.add(cross_ref=cross_refs.pop(0))
         transaction.events[0].asset.add(user_id=user1, asset_body=b'123456')
         transaction.events[1].asset.add(user_id=user1, asset_file=b'abcdefg')
+        transaction.get_sig_index(user1)
 
         sig = transaction.sign(keypair=clients[1]['keypair'])
         transaction.add_signature(user_id=user1, signature=sig)
@@ -106,6 +108,7 @@ class TestBBcCore(object):
 
     def test_04_1_search_transaction_by_txid_locally(self):
         print("-----", sys._getframe().f_code.co_name, "-----")
+        print(transaction.transaction_id.hex())
         ret = cores[1].search_transaction_by_txid(domain_id, asset_group_id, transaction.transaction_id,
                                                   clients[1]['user_id'], b'aaaa')
         print(ret)

--- a/tests/test_bbc_ledger.py
+++ b/tests/test_bbc_ledger.py
@@ -5,7 +5,7 @@ import sys
 sys.path.extend(["../"])
 from bbc1.common import bbclib
 from bbc1.core import bbc_ledger, bbc_config
-from bbc1.core.bbc_ledger import ResourceType
+from bbc1.core.bbc_types import ResourceType
 
 config = bbc_config.BBcConfig()
 ledger_manager =bbc_ledger.BBcLedger(config=config)

--- a/tests/test_bbc_network.py
+++ b/tests/test_bbc_network.py
@@ -12,7 +12,6 @@ sys.path.extend(["../"])
 from bbc1.common import bbclib
 from bbc1.common.message_key_types import KeyType
 from bbc1.core import bbc_network, bbc_config, query_management, bbc_stats
-from bbc1.core.bbc_ledger import ResourceType
 
 
 LOGLEVEL = 'debug'

--- a/tests/test_bbc_network_with_core.py
+++ b/tests/test_bbc_network_with_core.py
@@ -10,7 +10,7 @@ import sys
 sys.path.extend(["../"])
 from bbc1.common import bbclib
 from bbc1.common.message_key_types import KeyType
-from bbc1.core.bbc_ledger import ResourceType
+from bbc1.core.bbc_types import ResourceType
 from bbc1.core import query_management
 from testutils import prepare, start_core_thread, get_core_client
 
@@ -75,6 +75,7 @@ class TestBBcNetworkWithCore(object):
         simple_cluster.FORWARD_CACHE_SIZE = 5
         for i in range(core_nodes):
             cores[i].networking.create_domain(network_module="simple_cluster", domain_id=domain_id)
+            cores[i].ledger_manager.add_domain(domain_id)
             nodes[i] = cores[i].networking.domains[domain_id].node_id
             cores[i].networking.register_user_id(domain_id, users[i])
             cores[i].send_message = dummy_send_message

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -7,7 +7,7 @@ import time
 import sys
 sys.path.extend(["../"])
 from bbc1.app import bbc_app
-from bbc1.core.bbc_ledger import ResourceType
+from bbc1.core.bbc_types import ResourceType
 from bbc1.common import bbclib
 from bbc1.common.message_key_types import KeyType
 from bbc1.common.bbc_error import *


### PR DESCRIPTION
A domain setup procedure is done only in bbc_core.py. (Previously, it is done in bbc_core and bbc_network.)

This refactoring also changes the ledger_subsystem to an option. To use it, the config file (json file) should be edited (use_ledger_subsystem is newly introduced).