### PR TITLE
feat: implement domain/node key verification for administrative messages #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   #- pytest test_bbc_ethereum.py
   - pytest test_bbc_network.py
   - pytest test_bbc_network_encryption.py
-  - pytest test_bbc_network_with_core.py
   - pytest test_data_handler_sqlite.py
   - pytest test_key_exchange_manager.py
   - pytest test_bbclib.py

--- a/bbc1/common/bbc_error.py
+++ b/bbc1/common/bbc_error.py
@@ -18,6 +18,7 @@ limitations under the License.
 ESUCCESS        = 0
 EINVALID_COMMAND = -1
 ENODESTINATION  = -2
+EUNAUTHORIZED_COMMAND = -3
 
 ENOASSET        = -11
 EBADASSETDIGEST = -12

--- a/bbc1/core/bbc_config.py
+++ b/bbc1/core/bbc_config.py
@@ -43,6 +43,11 @@ current_config = {
         'p2p_port': DEFAULT_P2P_PORT,
         'max_connections': 100,
     },
+    'domain_auth_key': {
+        'use': False,
+        'directory': DEFAULT_WORKING_DIR,
+        'obsolete_timeout': 300,
+    },
     'domains': {
         '0000000000000000000000000000000000000000000000000000000000000000': {
             'module': 'p2p_domain0',
@@ -73,10 +78,11 @@ class BBcConfig:
     def __init__(self, directory=None, file=None):
         self.config = copy.deepcopy(current_config)
         self.config_file = DEFAULT_CONFIG_FILE
-        self.working_dir = self.config['workingdir']
         if directory is not None:
             self.working_dir = directory
             self.config['workingdir'] = self.working_dir
+        else:
+            self.working_dir = self.config['workingdir']
         if file is not None:
             self.config_file = file
 

--- a/bbc1/core/command.py
+++ b/bbc1/core/command.py
@@ -29,32 +29,18 @@ def parser():
             '[--ip4addr <IP addr>] [--ip6addr <IPv6 addr>] ' \
             '[--log <filename>] [--verbose_level <string>] [--daemon] [--kill] [--help]'.format(__file__)
     argparser = ArgumentParser(usage=usage)
-    argparser.add_argument('-cp', '--coreport', type=int, default=DEFAULT_CORE_PORT,
-                           help='waiting TCP port')
-    argparser.add_argument('-pp', '--p2pport', type=int, default=DEFAULT_P2P_PORT,
-                           help='waiting TCP port')
-    argparser.add_argument('-w', '--workingdir', type=str, default=".bbc1",
-                           help='working directory name')
-    argparser.add_argument('-c', '--config', type=str, default=None,
-                           help='config file name')
-    argparser.add_argument('--domain0',
-                           action='store_true',
-                           help='connect to domain_global_0')
-    argparser.add_argument('--ledgersubsystem',
-                           action='store_true',
-                           help='use ledger_subsystem')
-    argparser.add_argument('--ip4addr', type=str, default=None,
-                           help='IPv4 address exposed to the external network')
-    argparser.add_argument('--ip6addr', type=str, default=None,
-                           help='IPv6 address exposed to the external network')
-    argparser.add_argument('-l', '--log', type=str, default="-",
-                           help='log filename/"-" means STDOUT')
-    argparser.add_argument('-d', '--daemon',
-                           action='store_true',
-                           help='run in background')
-    argparser.add_argument('-k', '--kill',
-                           action='store_true',
-                           help='kill the daemon')
+    argparser.add_argument('-cp', '--coreport', type=int, default=DEFAULT_CORE_PORT, help='waiting TCP port')
+    argparser.add_argument('-pp', '--p2pport', type=int, default=DEFAULT_P2P_PORT, help='waiting TCP port')
+    argparser.add_argument('-w', '--workingdir', type=str, default=".bbc1", help='working directory name')
+    argparser.add_argument('-c', '--config', type=str, default=None, help='config file name')
+    argparser.add_argument('--nodekey', action='store_true', help='use default_node_key for admin command')
+    argparser.add_argument('--domain0', action='store_true', help='connect to domain_global_0')
+    argparser.add_argument('--ledgersubsystem', action='store_true', help='use ledger_subsystem')
+    argparser.add_argument('--ip4addr', type=str, default=None, help='IPv4 address exposed to the external network')
+    argparser.add_argument('--ip6addr', type=str, default=None, help='IPv6 address exposed to the external network')
+    argparser.add_argument('-l', '--log', type=str, default="-", help='log filename/"-" means STDOUT')
+    argparser.add_argument('-d', '--daemon', action='store_true', help='run in background')
+    argparser.add_argument('-k', '--kill', action='store_true', help='kill the daemon')
     argparser.add_argument('-v', '--verbose_level', type=str, default="debug",
                            help='log level all/debug/info/warning/error/critical/none')
     args = argparser.parse_args()

--- a/bbc1/core/key_exchange_manager.py
+++ b/bbc1/core/key_exchange_manager.py
@@ -71,7 +71,7 @@ class KeyExchangeManager:
         else:
             message_key_types.unset_cipher(key_name)
 
-    def remove_all_timers(self):
+    def stop_all_timers(self):
         if self.timer_entry is not None and self.timer_entry.active:
             self.timer_entry.deactivate()
 

--- a/tests/test_bbc_network_encryption_domain_key.py
+++ b/tests/test_bbc_network_encryption_domain_key.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import shutil
+import binascii
+import queue
+import random
+import time
+
+import os
+import sys
+sys.path.extend(["../"])
+
+from bbc1.common import bbclib, message_key_types
+from bbc1.common.message_key_types import KeyType
+from bbc1.core import bbc_network, bbc_config, query_management, bbc_stats
+from bbc1.core import key_exchange_manager
+from bbc1.core.topology_manager import TopologyManagerBase
+from bbc1.core.bbc_types import ResourceType
+
+
+LOGLEVEL = 'debug'
+LOGLEVEL = 'info'
+
+ticker = query_management.get_ticker()
+core_nodes = 2
+networkings = [None for i in range(core_nodes)]
+nodes = [None for i in range(core_nodes)]
+
+domain_id = bbclib.get_new_id("test_domain", include_timestamp=False)
+asset_group_id = bbclib.get_new_id("asset_group_1")
+users = [bbclib.get_new_id("test_user_%i" % i) for i in range(core_nodes)]
+key_names = [None for i in range(core_nodes)]
+result_queue = queue.Queue()
+
+sample_resource_id = bbclib.get_new_id("sample_resource_id")
+
+
+def get_random_data(length=16):
+    import random
+    source_str = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    return "".join([random.choice(source_str) for x in range(length)])
+
+
+def sleep_tick(wait_for):
+    end_time = time.time() + wait_for
+    while time.time() < end_time:
+        print("(%d) .. waiting" % int(time.time()))
+        time.sleep(1)
+
+
+class DummyCore:
+    class UserMessageRouting:
+        def add_domain(self, domain_id):
+            pass
+
+        def remove_domain(self, domain_id):
+            pass
+
+    def __init__(self):
+        self.user_message_routing = DummyCore.UserMessageRouting()
+        self.stats = bbc_stats.BBcStats()
+
+
+class TestBBcNetwork(object):
+
+    def test_00_key_setup(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        keypair = bbclib.KeyPair()
+        keypair.generate()
+        keyname = domain_id.hex() + ".pem"
+        with open(keyname, "wb") as f:
+            f.write(keypair.get_private_key_in_pem())
+
+    def test_01_start(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        key_exchange_manager.KeyExchangeManager.KEY_EXCHANGE_INVOKE_MAX_BACKOFF = 1
+        key_exchange_manager.KeyExchangeManager.KEY_EXCHANGE_RETRY_INTERVAL = 3
+        key_exchange_manager.KeyExchangeManager.KEY_REFRESH_INTERVAL = 15
+        key_exchange_manager.KeyExchangeManager.KEY_OBSOLETE_TIMER = 4
+        TopologyManagerBase.NEIGHBOR_LIST_REFRESH_INTERVAL = 15
+        dummycore = DummyCore()
+        keyconfig = {
+            'directory': ".",
+            'obsolete_timeout': 3,
+        }
+        global networkings, nodes, conf
+        for i, nw in enumerate(networkings):
+            if os.path.exists(".bbc1-%d"%i):
+                shutil.rmtree(".bbc1-%d"%i)
+            config = bbc_config.BBcConfig(directory=".bbc1-%d"%i)
+            conf = config.get_config()
+            conf["domain_auth_key"].update(keyconfig)
+            networkings[i] = bbc_network.BBcNetwork(core=dummycore, config=config, p2p_port=6641+i, loglevel=LOGLEVEL)
+            networkings[i].create_domain(domain_id=domain_id)
+            nodes[i] = networkings[i].domains[domain_id]['neighbor'].my_node_id
+            assert nodes[i] is not None
+            assert networkings[i].ip_address != ''
+            print("IPv4: %s, IPv6 %s, port: %d" % (networkings[i].ip_address, networkings[i].ip6_address,
+                                                   networkings[i].port))
+
+    def test_02_set_initial_peer(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        for i in range(1, core_nodes):
+            networkings[i].add_neighbor(domain_id=domain_id, node_id=nodes[0],
+                                        ipv4=networkings[0].ip_address, port=networkings[0].port)
+            print(networkings[i].domains[domain_id]['neighbor'].show_list())
+
+    def test_03_wait_and_show(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        print("-- wait 2 seconds --")
+        global key_names
+        sleep_tick(2)
+        for i in range(core_nodes):
+            #print(networkings[i].domains[domain_id]['neighbor'].show_list())
+            for nd in networkings[i].domains[domain_id]['neighbor'].nodeinfo_list.values():
+                assert nd.key_manager.state == key_exchange_manager.KeyExchangeManager.STATE_ESTABLISHED
+                assert nd.key_manager.key_name in message_key_types.encryptors
+                key_names[i] = nd.key_manager.key_name
+
+        for i in range(core_nodes):
+            print("keynames[%d]=%s" % (i, key_names[i].hex()[:10]))
+        for k in message_key_types.encryptors.keys():
+            print("key_name=%s" % k.hex()[:10])
+
+    def test_04_wait(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        print("-- wait 10 seconds (should be established) --")
+        sleep_tick(10)
+        for i in range(core_nodes):
+            for nd in networkings[i].domains[domain_id]['neighbor'].nodeinfo_list.values():
+                assert nd.key_manager.state == key_exchange_manager.KeyExchangeManager.STATE_ESTABLISHED
+                assert nd.key_manager.key_name in message_key_types.encryptors
+                assert key_names[i] in message_key_types.encryptors
+        for k in message_key_types.encryptors.keys():
+            print("key_name=%s" % k.hex()[:10])
+
+    def test_05_wait_refresh(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        print("-- wait 15 seconds (will occur refresh and re-established) --")
+        sleep_tick(15)
+        for k in message_key_types.encryptors.keys():
+            print("key_name=%s" % k.hex()[:10])
+        for i in range(core_nodes):
+            for nd in networkings[i].domains[domain_id]['neighbor'].nodeinfo_list.values():
+                assert nd.key_manager.state == key_exchange_manager.KeyExchangeManager.STATE_ESTABLISHED
+                assert nd.key_manager.key_name in message_key_types.encryptors
+                assert key_names[i] not in message_key_types.encryptors
+        assert len(message_key_types.encryptors) == 2
+
+    def test_06_domain_key_change(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        keypair = bbclib.KeyPair()
+        keypair.generate()
+        keyname = domain_id.hex() + ".pem"
+        with open(keyname, "wb") as f:
+            f.write(keypair.get_private_key_in_pem())
+
+        for i, nw in enumerate(networkings):
+            nw.get_domain_keypair(domain_id)
+
+        keypair = bbclib.KeyPair()
+        keypair.generate()
+        keyname = domain_id.hex() + ".pem"
+        with open(keyname, "wb") as f:
+            f.write(keypair.get_private_key_in_pem())
+
+        for i, nw in enumerate(networkings):
+            nw.get_domain_keypair(domain_id)
+
+    def test_07_wait(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        print("-- wait 25 seconds (will occur refresh and re-established) --")
+        sleep_tick(25)
+
+    def test_08_delete_key(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        keyname = domain_id.hex() + ".pem"
+        os.remove(keyname)
+        for i, nw in enumerate(networkings):
+            nw.get_domain_keypair(domain_id)
+
+        print("-- wait 15 seconds (will occur refresh and re-established) --")
+        sleep_tick(15)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/test_msg_serializer.py
+++ b/tests/test_msg_serializer.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import sys
+sys.path.extend(["../"])
+import pprint
+
+#import unittest
+from bbc1.common import message_key_types, bbclib
+from bbc1.common.message_key_types import KeyType
+
+msg_data = None
+
+
+class TestMsgSerializer(object):
+
+    def test_01_serialize(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        msg = {
+            KeyType.source_node_id: bbclib.get_new_id("aaa"),
+            KeyType.destination_node_id: bbclib.get_new_id("bbb"),
+            KeyType.status: True,
+            KeyType.random: int(8000).to_bytes(4, "little")
+        }
+        pprint.pprint(msg)
+        global msg_data
+        msg_data = message_key_types.make_TLV_formatted_message(msg)
+
+    def test_02_deserialize(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        msg = message_key_types.make_dictionary_from_TLV_format(msg_data)
+        pprint.pprint(msg)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -33,21 +33,23 @@ def get_core_client():
     return cores, clients
 
 
-def start_core_thread(index, core_port_increment=0, p2p_port_increment=0, use_domain0=False, remove_dir=True):
+def start_core_thread(index, core_port_increment=0, p2p_port_increment=0,
+                      use_nodekey=False, use_domain0=False, remove_dir=True):
     core_port = DEFAULT_CORE_PORT + core_port_increment
     p2p_port = DEFAULT_P2P_PORT + p2p_port_increment
-    th = threading.Thread(target=start_core, args=(index, core_port, p2p_port, use_domain0, remove_dir,))
+    th = threading.Thread(target=start_core, args=(index, core_port, p2p_port, use_nodekey, use_domain0, remove_dir,))
     th.setDaemon(True)
     th.start()
     time.sleep(0.1)
 
 
-def start_core(index, core_port, p2p_port, use_domain0=False, remove_dir=True):
+def start_core(index, core_port, p2p_port, use_nodekey=False, use_domain0=False, remove_dir=True):
     print("** [%d] start: port=%i" % (index, core_port))
     if remove_dir and os.path.exists(".bbc1-%i/" % core_port):
         shutil.rmtree(".bbc1-%i/" % core_port)
     cores[index] = bbc_core.BBcCoreService(p2p_port=p2p_port, core_port=core_port,
                                            workingdir=".bbc1-%i/" % core_port,
+                                           use_nodekey=use_nodekey,
                                            use_domain0=use_domain0,
                                            server_start=False,
                                            loglevel=loglv)


### PR DESCRIPTION
This PR introduces domain_key and node_key for access control of administrators.

These keys are used for making a sign to an administrative message. Without a valid signature, bbc_core discards the received message without any response.

Domain key should be provided by an domain administrator and all bbc_core nodes joining the domain must have that key. Node key should be provided by the system administrator (who might deployed the system). The node key is used for creating domain and get statistics through bbc_app.
