### PR TITLE
#103 tominaga

### DIFF
--- a/bbc1/core/bbc_core.py
+++ b/bbc1/core/bbc_core.py
@@ -641,6 +641,7 @@ class BBcCoreService:
             if not retmsg[KeyType.result]:
                 retmsg[KeyType.reason] = "Already exists"
             retmsg[KeyType.domain_id] = domain_id
+            self.config.update_config()
             user_message_routing.direct_send_to_user(socket, retmsg)
 
         elif cmd == MsgType.REQUEST_CLOSE_DOMAIN:

--- a/bbc1/core/data_handler.py
+++ b/bbc1/core/data_handler.py
@@ -483,8 +483,6 @@ class DataHandler:
                 conditions.append("user_id = %s " % self.db_adaptors[0].placeholder)
             sql += "AND ".join(conditions) + "ORDER BY id %s" % dire
             if count > 0:
-                if count > 20:
-                    count = 20
                 sql += " limit %d" % count
             sql += ";"
             args = list(filter(lambda a: a is not None, (asset_group_id, asset_id, user_id)))


### PR DESCRIPTION
search_transaction sets limit to the maximum number of transactions to retrieve.
Even if count argument is over 20, count is set 20.
Delete limitation.