### PR TITLE
#104 tominaga

### DIFF
--- a/bbc1/core/bbc_core.py
+++ b/bbc1/core/bbc_core.py
@@ -108,13 +108,15 @@ def _create_search_result(txobj_dict, asset_files_dict):
     for txid, txobj in txobj_dict.items():
         if txid != txobj.transaction_id:
             response_info.setdefault(KeyType.compromised_transactions, list()).append(txobj.transaction_data)
+            response_info.setdefault(KeyType.compromised_transaction_ids, list()).append(txid)
             continue
         txobj_is_valid, valid_assets, invalid_assets = bbclib.validate_transaction_object(txobj, asset_files_dict)
         if txobj_is_valid:
             response_info.setdefault(KeyType.transactions, list()).append(txobj.transaction_data)
         else:
             response_info.setdefault(KeyType.compromised_transactions, list()).append(txobj.transaction_data)
-
+            response_info.setdefault(KeyType.compromised_transaction_ids, list()).append(txid)
+            
         if len(valid_assets) > 0:
             response_info.setdefault(KeyType.all_asset_files, dict())
             for asgid, asid in valid_assets:

--- a/bbc1/core/bbc_core.py
+++ b/bbc1/core/bbc_core.py
@@ -641,6 +641,7 @@ class BBcCoreService:
             if not retmsg[KeyType.result]:
                 retmsg[KeyType.reason] = "Already exists"
             retmsg[KeyType.domain_id] = domain_id
+            self.config.update_config()
             user_message_routing.direct_send_to_user(socket, retmsg)
 
         elif cmd == MsgType.REQUEST_CLOSE_DOMAIN:

--- a/bbc1/core/message_key_types.py
+++ b/bbc1/core/message_key_types.py
@@ -326,7 +326,8 @@ class KeyType:
     compromised_transaction_data = to_4byte(0, 0x90)
     compromised_transactions = to_4byte(1, 0x90)
     compromised_asset_files = to_4byte(2, 0x90)
-
+    compromised_transaction_ids = to_4byte(3, 0x90)
+    
     ledger_subsys_manip = to_4byte(0, 0xA0)     # enable/disable ledger_subsystem
     ledger_subsys_register = to_4byte(1, 0xA0)
     ledger_subsys_verify = to_4byte(2, 0xA0)


### PR DESCRIPTION
There isn't attribute for compromised transaction id in KeyType.
So, add new key named compromised_transaction_ids into KeyType.

When searching transaction, if txid doesn't match txobj.transaction_id, append txid(compromised transaction id) into KeyType.compromised_transaction_ids.
And also, when txobj is invalid, append its id into KeyType.compromised_transaction_ids.