### PR TITLE
[update] bug fix for data_handler.py

### DIFF
--- a/bbc1/core/data_handler.py
+++ b/bbc1/core/data_handler.py
@@ -483,8 +483,6 @@ class DataHandler:
                 conditions.append("user_id = %s " % self.db_adaptors[0].placeholder)
             sql += "AND ".join(conditions) + "ORDER BY id %s" % dire
             if count > 0:
-                if count > 20:
-                    count = 20
                 sql += " limit %d" % count
             sql += ";"
             args = list(filter(lambda a: a is not None, (asset_group_id, asset_id, user_id)))


### PR DESCRIPTION
instead of #107 

> search_transaction sets limit to the maximum number of transactions to retrieve.
> Even if count argument is over 20, count is set 20.
> Delete limitation.

This PR removed commit (6a1137f) from #107 