### PR TITLE
fix bug on recovering mapping betwenn user_id and signature index (#122)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - pytest test_data_handler_sqlite.py
   - pytest test_key_exchange_manager.py
   - pytest test_bbclib.py
+  - pytest test_bbclib_pack_unpack.py
   - pytest test_pending_request.py
   - pytest test_bbc_ping.py
   - pytest test_bbc_stats.py

--- a/bbc1/core/libs/bbclib_reference.py
+++ b/bbc1/core/libs/bbclib_reference.py
@@ -56,12 +56,23 @@ class BBcReference:
         self.ref_transaction = ref_transaction
         try:
             evt = ref_transaction.events[self.event_index_in_ref]
-            for user in evt.mandatory_approvers:
-                self.sig_indices.append(self.transaction.get_sig_index(user))
-            for i in range(evt.option_approver_num_numerator):
-                dummy_id = bbclib_utils.get_random_value(4)
-                self.option_sig_ids.append(dummy_id)
-                self.sig_indices.append(self.transaction.get_sig_index(dummy_id))
+            if len(self.sig_indices) == 0:
+                for user in evt.mandatory_approvers:
+                    self.sig_indices.append(self.transaction.get_sig_index(user))
+                for i in range(evt.option_approver_num_numerator):
+                    dummy_id = bbclib_utils.get_random_value(4)
+                    self.option_sig_ids.append(dummy_id)
+                    self.sig_indices.append(self.transaction.get_sig_index(dummy_id))
+            else:
+                i = 0
+                for user in evt.mandatory_approvers:
+                    self.transaction.set_sig_index(user, self.sig_indices[i])
+                    i += 1
+                for i in range(evt.option_approver_num_numerator):
+                    dummy_id = bbclib_utils.get_random_value(4)
+                    self.option_sig_ids.append(dummy_id)
+                    self.transaction.set_sig_index(dummy_id, self.sig_indices[i])
+                    i += 1
             self.mandatory_approvers = evt.mandatory_approvers
             self.option_approvers = evt.option_approvers
             ref_transaction.digest()

--- a/bbc1/core/libs/bbclib_transaction.py
+++ b/bbc1/core/libs/bbclib_transaction.py
@@ -133,6 +133,17 @@ class BBcTransaction:
             self.signatures.append(BBcSignature())
         return self.userid_sigidx_mapping[user_id]
 
+    def set_sig_index(self, user_id, idx):
+        """Map a user_id with the index of signature list
+
+        Args:
+            user_id (bytes): user_id whose signature will be added to the signature part
+            idx (int): index number
+        """
+        if user_id in self.userid_sigidx_mapping:
+            return
+        self.userid_sigidx_mapping[user_id] = idx
+
     def add_signature(self, user_id=None, signature=None):
         """Add signature in the reserved space
 
@@ -250,7 +261,7 @@ class BBcTransaction:
             for i in range(ref_num):
                 ptr, size = bbclib_utils.get_n_byte_int(ptr, 4, data)
                 ptr, refdata = bbclib_utils.get_n_bytes(ptr, size, data)
-                refe = BBcReference(None, None, id_length=self.id_length)
+                refe = BBcReference(None, self, id_length=self.id_length)
                 if not refe.unpack(refdata):
                     return False
                 self.references.append(refe)

--- a/bbc1/core/libs/bbclib_witness.py
+++ b/bbc1/core/libs/bbclib_witness.py
@@ -91,7 +91,7 @@ class BBcWitness:
                 self.sig_indices.append(idx)
                 if ptr > data_size:
                     return False
-                self.transaction.get_sig_index(uid[:self.id_length])
+                self.transaction.set_sig_index(uid[:self.id_length], idx)
         except:
             return False
         return True

--- a/docs/BBc-1_transaction_data_ja.md
+++ b/docs/BBc-1_transaction_data_ja.md
@@ -871,4 +871,4 @@ key_type=0の場合は、key_length以降すべてのデータを省略する。
 
 # 他言語への移植
 
-bbclib、つまりトランザクションデータそのものの操作機能を他のプログラミング言語に移植する場合も、[図1](#fig1)およびその後に示したとおりに，packed binary dataとBBcTranactionオブジェクトの変換が行えれば良い。2018年12月現在、[Go言語版](https://github.com/beyond-blockchain/bbclib-go)が存在する。
+bbclib、つまりトランザクションデータそのものの操作機能を他のプログラミング言語に移植する場合も、[図1](#fig1)およびその後に示したとおりに，packed binary dataとBBcTranactionオブジェクトの変換が行えれば良い。2019年1月現在、[Go言語版](https://github.com/beyond-blockchain/bbclib-go)と[Javascript版](https://github.com/beyond-blockchain/js-bbclib)が存在する。

--- a/tests/test_bbclib_pack_unpack.py
+++ b/tests/test_bbclib_pack_unpack.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import binascii
+import sys
+sys.path.extend(["../"])
+from bbc1.core.bbclib import KeyPair
+from bbc1.core import bbclib
+
+users = list()
+domain_id = bbclib.get_new_id("testdomain")
+asset_group_id = bbclib.get_new_id("asset_group_1")
+
+
+class TestBBcLib(object):
+
+    def test_00_user_setup(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        global users
+        for i in range(0, 5):
+            users.append([bbclib.get_new_id("user_%d" % i), KeyPair()])
+            users[i][1].generate()
+
+    def test_01_transaction_with_relation(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        transaction1 = bbclib.make_transaction(relation_num=1, witness=True)
+        bbclib.add_relation_asset(transaction1, relation_idx=0, asset_group_id=asset_group_id,
+                                  user_id=users[0][0], asset_body=b'ccccc')
+        for u in users:
+            transaction1.witness.add_witness(user_id=u[0])
+
+        packed_data = transaction1.pack()
+        unpacked_txobj = bbclib.BBcTransaction()
+        unpacked_txobj.unpack(packed_data)
+
+        print(unpacked_txobj)
+        for u in users:
+            sig = unpacked_txobj.sign(keypair=u[1])
+            unpacked_txobj.add_signature(user_id=u[0], signature=sig)
+            transaction1.add_signature(user_id=u[0], signature=sig)
+
+        original_packed_tx = transaction1.pack()
+        recovered_packed_tx = unpacked_txobj.pack()
+
+        assert original_packed_tx == recovered_packed_tx
+        print(transaction1)
+
+    def test_02_transaction_with_reference_relation(self):
+        print("\n-----", sys._getframe().f_code.co_name, "-----")
+        print("**** prepare original (previous) transaction to refer to")
+        transaction1 = bbclib.make_transaction(event_num=1, witness=True)
+        transaction1.events[0].add(mandatory_approver=users[0][0])
+        transaction1.events[0].add(mandatory_approver=users[1][0])
+        bbclib.add_event_asset(transaction1, event_idx=0, asset_group_id=asset_group_id, user_id=users[0][0], asset_body=b"data1")
+        transaction1.witness.add_witness(user_id=users[0][0])
+        sig = transaction1.sign(keypair=users[0][1])
+        transaction1.add_signature(user_id=users[0][0], signature=sig)
+        transaction1.digest()
+        print(transaction1)
+
+        transaction2 = bbclib.make_transaction(relation_num=1, witness=True)
+        bbclib.add_relation_asset(transaction2, relation_idx=0, asset_group_id=asset_group_id,
+                                  user_id=users[0][0], asset_body=b'ccccc')
+        transaction2.witness.add_witness(user_id=users[2][0])
+        bbclib.add_reference_to_transaction(transaction2, asset_group_id, transaction1, 0)
+        transaction2.witness.add_witness(user_id=users[3][0])
+        print(transaction2)
+
+        packed_data = transaction2.pack()
+        unpacked_txobj = bbclib.BBcTransaction()
+        unpacked_txobj.unpack(packed_data)
+        unpacked_txobj.references[0].prepare_reference(transaction1)
+        #print(unpacked_txobj)
+
+        for i in range(len(users)-2, -1, -1):
+            sig = unpacked_txobj.sign(keypair=users[i][1])
+            unpacked_txobj.add_signature(user_id=users[i][0], signature=sig)
+            transaction2.add_signature(user_id=users[i][0], signature=sig)
+
+        print(unpacked_txobj)
+        original_packed_tx = transaction2.pack()
+        recovered_packed_tx = unpacked_txobj.pack()
+        assert original_packed_tx == recovered_packed_tx


### PR DESCRIPTION
Fix bbclib_xxxx (witness, reference, transaction) to set indices properly in unpacking.