### PR TITLE
update setup.py (add long_description_content_type)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     name='bbc1',
     version='1.4',
     description='A core system of Beyond Blockchain One',
+    long_description_content_type='text/markdown',
     long_description=readme,
     url='https://github.com/beyond-blockchain/bbc1',
     author='beyond-blockchain.org',


### PR DESCRIPTION
For uploading this lib to pypi as a python package with twine command, "long_description_content_type" parameter is necessary. 
For confirmation, I tested uploading the python package to testpypi. And it succeeded.