### PR TITLE
conforming to a py-bbclib change.

### DIFF
--- a/examples/file_proof/file_proof.py
+++ b/examples/file_proof/file_proof.py
@@ -312,7 +312,7 @@ def store_proc(file, txid=None):
     sig = store_transaction.sign(private_key=key_pair.private_key,
                                  public_key=key_pair.public_key)
     store_transaction.get_sig_index(user_id)
-    store_transaction.add_signature(user_id=user_id, signature=sig)
+    store_transaction.add_signature_object(user_id=user_id, signature=sig)
     store_transaction.digest()
     print(store_transaction)
 


### PR DESCRIPTION
file_proof example seems to need an update according to the interface change in py-bbclib.